### PR TITLE
Add net profit calculations

### DIFF
--- a/comparison_price/spot_futures_compare.go
+++ b/comparison_price/spot_futures_compare.go
@@ -3,6 +3,7 @@ package comparison_price
 import (
 	"basis_go/funding"
 	"basis_go/types"
+	"basis_go/utils"
 	"fmt"
 	"sort"
 )
@@ -79,11 +80,12 @@ func CompareSpotFutures(spotPrices, futuresPrices types.TokenPrices) {
 	}
 
 	for _, r := range results[:limit] {
-		fmt.Printf("[%s]\n- %s (%s, %s) → %s (%s, %s) | %.6f → %.6f | Спред: %.2f%%\n",
+		net := utils.NetSpread(r.spread, utils.DefaultMakerFeePercent, utils.DefaultTakerFeePercent, 0)
+		fmt.Printf("[%s]\n- %s (%s, %s) → %s (%s, %s) | %.6f → %.6f | Спред: %.2f%% (Чистый: %.2f%%)\n",
 			r.token,
 			r.ex1, r.t1, formatFunding(r.f1),
 			r.ex2, r.t2, formatFunding(r.f2),
-			r.p1, r.p2, r.spread)
+			r.p1, r.p2, r.spread, net)
 	}
 	fmt.Println("====================================")
 }

--- a/core/analyzer.go
+++ b/core/analyzer.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"basis_go/types"
+	"basis_go/utils"
 )
 
 func typeName(p types.ExchangePrice) string {
@@ -50,10 +51,15 @@ func CompareAll(prices types.TokenPrices) {
 						printed = true
 					}
 
-					fmt.Printf("- %s (%s) → %s (%s) | %.6f → %.6f | Спред: %.2f%%%s%s\n",
+					var fundingDiff float64
+					if p1.IsFutures || p2.IsFutures {
+						fundingDiff = (p2.FundingRate - p1.FundingRate) * 100
+					}
+					net := utils.NetSpread(spread, utils.DefaultMakerFeePercent, utils.DefaultTakerFeePercent, fundingDiff)
+					fmt.Printf("- %s (%s) → %s (%s) | %.6f → %.6f | Спред: %.2f%% (Чистый: %.2f%%)%s%s\n",
 						ex1, typeName(p1),
 						ex2, typeName(p2),
-						p1.Price, p2.Price, spread,
+						p1.Price, p2.Price, spread, net,
 						fundingInfo(p1), fundingInfo(p2),
 					)
 				}

--- a/futures/utils.go
+++ b/futures/utils.go
@@ -71,12 +71,12 @@ func ComparePrices(prices types.TokenPrices) {
 			nextFundingTime = r.f2.FundingTime
 		}
 		timeUntil := funding.FormatNextFundingTime(nextFundingTime)
-
-		fmt.Printf("[%s]\n- %s (%s) → %s (%s, ∆Фандинг: %.3f%%, через %s) | %.6f → %.6f | Спред: %.2f%%\n",
+		net := utils.NetSpread(r.spread, utils.DefaultMakerFeePercent, utils.DefaultTakerFeePercent, fundingDiff)
+		fmt.Printf("[%s]\n- %s (%s) → %s (%s, ∆Фандинг: %.3f%%, через %s) | %.6f → %.6f | Спред: %.2f%% (Чистый: %.2f%%)\n",
 			r.token,
 			r.ex1, r.t1,
 			r.ex2, r.t2, fundingDiff, timeUntil,
-			r.p1, r.p2, r.spread)
+			r.p1, r.p2, r.spread, net)
 	}
 	fmt.Println("====================================")
 }

--- a/spot/utils.go
+++ b/spot/utils.go
@@ -60,8 +60,9 @@ func CompareSpotPrices(prices types.TokenPrices) {
 	}
 
 	for _, r := range results[:limit] {
-		fmt.Printf("[%s]\n- %s (%s) → %s (%s) | %.6f → %.6f | Спред: %.2f%%\n",
-			r.token, r.ex1, r.t1, r.ex2, r.t2, r.p1, r.p2, r.spread)
+		net := utils.NetSpread(r.spread, utils.DefaultMakerFeePercent, utils.DefaultTakerFeePercent, 0)
+		fmt.Printf("[%s]\n- %s (%s) → %s (%s) | %.6f → %.6f | Спред: %.2f%% (Чистый: %.2f%%)\n",
+			r.token, r.ex1, r.t1, r.ex2, r.t2, r.p1, r.p2, r.spread, net)
 	}
 	fmt.Println("====================================")
 }

--- a/utils/spread.go
+++ b/utils/spread.go
@@ -1,5 +1,11 @@
 package utils
 
+// Default estimated fees in percent (e.g. 0.1 means 0.1%).
+const (
+	DefaultMakerFeePercent = 0.02
+	DefaultTakerFeePercent = 0.07
+)
+
 // CalculateSpotSpread — расчёт спреда для спотового рынка
 func CalculateSpotSpread(p1, p2 float64) float64 {
 	if p1 <= 0 || p2 <= 0 {
@@ -14,4 +20,12 @@ func CalculateFuturesSpread(p1, p2 float64) float64 {
 		return 0
 	}
 	return ((p2 - p1) / p1) * 100
+}
+
+// NetSpread subtracts maker/taker fees and funding costs from the spread.
+// makerFeePercent and takerFeePercent should be provided as percentages
+// (e.g. 0.1 for 0.1%). fundingDiffPercent represents the expected funding
+// payment difference in percent.
+func NetSpread(spreadPercent, makerFeePercent, takerFeePercent, fundingDiffPercent float64) float64 {
+	return spreadPercent - makerFeePercent - takerFeePercent - fundingDiffPercent
 }

--- a/utils/spread_test.go
+++ b/utils/spread_test.go
@@ -1,0 +1,33 @@
+package utils
+
+import (
+    "math"
+    "testing"
+)
+
+func TestCalculateSpotSpread(t *testing.T) {
+    if v := CalculateSpotSpread(100, 105); v != 5 {
+        t.Errorf("expected 5, got %v", v)
+    }
+    if v := CalculateSpotSpread(0, 100); v != 0 {
+        t.Errorf("expected 0 for invalid input, got %v", v)
+    }
+}
+
+func TestCalculateFuturesSpread(t *testing.T) {
+    if v := CalculateFuturesSpread(200, 210); v != 5 {
+        t.Errorf("expected 5, got %v", v)
+    }
+    if v := CalculateFuturesSpread(-1, 0); v != 0 {
+        t.Errorf("expected 0 for invalid input, got %v", v)
+    }
+}
+
+func TestNetSpread(t *testing.T) {
+    // spread 2.5%, maker 0.02%, taker 0.07%, funding 0.01%
+    expected := 2.5 - 0.02 - 0.07 - 0.01
+    if v := NetSpread(2.5, 0.02, 0.07, 0.01); math.Abs(v-expected) > 1e-9 {
+        t.Errorf("expected %v, got %v", expected, v)
+    }
+}
+


### PR DESCRIPTION
## Summary
- add default fee constants and NetSpread helper
- show net profits in spot, futures and spot-vs-futures output
- include fees/funding in all-in-one analyzer output
- add tests for spread utilities

## Testing
- `go vet ./...`
- `go test ./...`
