### PR TITLE
Use per-exchange fees in spread calculations

### DIFF
--- a/comparison_price/spot_futures_compare.go
+++ b/comparison_price/spot_futures_compare.go
@@ -80,7 +80,9 @@ func CompareSpotFutures(spotPrices, futuresPrices types.TokenPrices) {
 	}
 
 	for _, r := range results[:limit] {
-		net := utils.NetSpread(r.spread, utils.DefaultMakerFeePercent, utils.DefaultTakerFeePercent, 0)
+		makerFee := utils.GetFees(r.ex1).Maker
+		takerFee := utils.GetFees(r.ex2).Taker
+		net := utils.NetSpread(r.spread, makerFee, takerFee, 0)
 		fmt.Printf("[%s]\n- %s (%s, %s) → %s (%s, %s) | %.6f → %.6f | Спред: %.2f%% (Чистый: %.2f%%)\n",
 			r.token,
 			r.ex1, r.t1, formatFunding(r.f1),

--- a/core/analyzer.go
+++ b/core/analyzer.go
@@ -55,7 +55,9 @@ func CompareAll(prices types.TokenPrices) {
 					if p1.IsFutures || p2.IsFutures {
 						fundingDiff = (p2.FundingRate - p1.FundingRate) * 100
 					}
-					net := utils.NetSpread(spread, utils.DefaultMakerFeePercent, utils.DefaultTakerFeePercent, fundingDiff)
+					makerFee := utils.GetFees(ex1).Maker
+					takerFee := utils.GetFees(ex2).Taker
+					net := utils.NetSpread(spread, makerFee, takerFee, fundingDiff)
 					fmt.Printf("- %s (%s) → %s (%s) | %.6f → %.6f | Спред: %.2f%% (Чистый: %.2f%%)%s%s\n",
 						ex1, typeName(p1),
 						ex2, typeName(p2),

--- a/futures/utils.go
+++ b/futures/utils.go
@@ -71,7 +71,9 @@ func ComparePrices(prices types.TokenPrices) {
 			nextFundingTime = r.f2.FundingTime
 		}
 		timeUntil := funding.FormatNextFundingTime(nextFundingTime)
-		net := utils.NetSpread(r.spread, utils.DefaultMakerFeePercent, utils.DefaultTakerFeePercent, fundingDiff)
+		makerFee := utils.GetFees(r.ex1).Maker
+		takerFee := utils.GetFees(r.ex2).Taker
+		net := utils.NetSpread(r.spread, makerFee, takerFee, fundingDiff)
 		fmt.Printf("[%s]\n- %s (%s) → %s (%s, ∆Фандинг: %.3f%%, через %s) | %.6f → %.6f | Спред: %.2f%% (Чистый: %.2f%%)\n",
 			r.token,
 			r.ex1, r.t1,

--- a/spot/utils.go
+++ b/spot/utils.go
@@ -60,7 +60,9 @@ func CompareSpotPrices(prices types.TokenPrices) {
 	}
 
 	for _, r := range results[:limit] {
-		net := utils.NetSpread(r.spread, utils.DefaultMakerFeePercent, utils.DefaultTakerFeePercent, 0)
+		makerFee := utils.GetFees(r.ex1).Maker
+		takerFee := utils.GetFees(r.ex2).Taker
+		net := utils.NetSpread(r.spread, makerFee, takerFee, 0)
 		fmt.Printf("[%s]\n- %s (%s) → %s (%s) | %.6f → %.6f | Спред: %.2f%% (Чистый: %.2f%%)\n",
 			r.token, r.ex1, r.t1, r.ex2, r.t2, r.p1, r.p2, r.spread, net)
 	}

--- a/utils/spread.go
+++ b/utils/spread.go
@@ -6,6 +6,34 @@ const (
 	DefaultTakerFeePercent = 0.07
 )
 
+// FeeInfo holds maker/taker fees for a particular exchange.
+type FeeInfo struct {
+	Maker float64
+	Taker float64
+}
+
+// ExchangeFees lists maker and taker fees by exchange name. The names should
+// match what the Exchange implementations return from the Name() method.
+var ExchangeFees = map[string]FeeInfo{
+	"Binance Spot":    {Maker: 0.02, Taker: 0.07},
+	"Binance Futures": {Maker: 0.02, Taker: 0.07},
+	"MEXC Spot":       {Maker: 0.02, Taker: 0.07},
+	"MEXC Futures":    {Maker: 0.02, Taker: 0.07},
+	"Gate.io Spot":    {Maker: 0.02, Taker: 0.07},
+	"Gate Futures":    {Maker: 0.02, Taker: 0.07},
+	"Bybit Spot":      {Maker: 0.02, Taker: 0.07},
+	"Bybit Futures":   {Maker: 0.02, Taker: 0.07},
+}
+
+// GetFees returns the fee info for the given exchange. If the exchange is not
+// found in the table, the default fees are returned as a fallback.
+func GetFees(exchange string) FeeInfo {
+	if f, ok := ExchangeFees[exchange]; ok {
+		return f
+	}
+	return FeeInfo{Maker: DefaultMakerFeePercent, Taker: DefaultTakerFeePercent}
+}
+
 // CalculateSpotSpread — расчёт спреда для спотового рынка
 func CalculateSpotSpread(p1, p2 float64) float64 {
 	if p1 <= 0 || p2 <= 0 {


### PR DESCRIPTION
## Summary
- add `FeeInfo` struct and per-exchange fee table
- use `GetFees` when calculating net spreads for spot, futures and comparisons
- update analyzer to subtract fees based on exchange names

## Testing
- `go build ./...`
- `go test ./...`
