### PR TITLE
Refactor price collectors to accept custom fetchers

### DIFF
--- a/futures/collect.go
+++ b/futures/collect.go
@@ -11,7 +11,7 @@ import (
 	"basis_go/types"
 )
 
-func CollectFuturesPrices() types.TokenPrices {
+func CollectFuturesPrices(fetchers ...map[string]func() map[string]types.ExchangePrice) types.TokenPrices {
 	all := make(types.TokenPrices)
 	wg := sync.WaitGroup{}
 	mu := sync.Mutex{}
@@ -29,6 +29,10 @@ func CollectFuturesPrices() types.TokenPrices {
 		"Bybit Futures": func() map[string]types.ExchangePrice {
 			return (&bybit.BybitFutures{}).GetPrices()
 		},
+	}
+
+	if len(fetchers) > 0 && fetchers[0] != nil {
+		sources = fetchers[0]
 	}
 
 	wg.Add(len(sources))

--- a/futures/collect_test.go
+++ b/futures/collect_test.go
@@ -1,0 +1,52 @@
+package futures
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"basis_go/types"
+)
+
+func TestCollectFuturesPrices_WithFetchers(t *testing.T) {
+	fetchers := map[string]func() map[string]types.ExchangePrice{
+		"f1": func() map[string]types.ExchangePrice {
+			return map[string]types.ExchangePrice{
+				"BTC/USDT": {Price: 1},
+			}
+		},
+		"f2": func() map[string]types.ExchangePrice {
+			return map[string]types.ExchangePrice{
+				"BTC/USDT": {Price: 2},
+				"ETH/USDT": {Price: 3},
+			}
+		},
+		"empty": func() map[string]types.ExchangePrice { return nil },
+	}
+
+	r, w, _ := os.Pipe()
+	old := os.Stdout
+	os.Stdout = w
+	res := CollectFuturesPrices(fetchers)
+	w.Close()
+	os.Stdout = old
+	var buf bytes.Buffer
+	io.Copy(&buf, r)
+	out := buf.String()
+
+	if !strings.Contains(out, "[empty] ФЬЮЧЕРС НЕ ОТДАЁТ ДАННЫХ") {
+		t.Fatalf("expected warning for empty fetcher, got: %s", out)
+	}
+
+	if len(res) != 2 {
+		t.Fatalf("expected 2 tokens, got %d", len(res))
+	}
+	if len(res["BTC/USDT"]) != 2 {
+		t.Fatalf("expected BTC/USDT on 2 exchanges, got %v", res["BTC/USDT"])
+	}
+	if p := res["ETH/USDT"]["f2"].Price; p != 3 {
+		t.Fatalf("expected ETH price 3, got %v", p)
+	}
+}

--- a/spot/collect.go
+++ b/spot/collect.go
@@ -10,7 +10,7 @@ import (
 	"sync"
 )
 
-func CollectSpotPrices() types.TokenPrices {
+func CollectSpotPrices(fetchers ...map[string]func() map[string]types.ExchangePrice) types.TokenPrices {
 	all := make(types.TokenPrices)
 	wg := sync.WaitGroup{}
 	mu := sync.Mutex{}
@@ -20,6 +20,10 @@ func CollectSpotPrices() types.TokenPrices {
 		"MEXC Spot":    mexc.GetSpotPrices,
 		"Gate Spot":    (&gate.GateSpot{}).GetPrices,
 		"Bybit Spot":   bybit.GetSpotPrices,
+	}
+
+	if len(fetchers) > 0 && fetchers[0] != nil {
+		sources = fetchers[0]
 	}
 
 	wg.Add(len(sources))

--- a/spot/collect_test.go
+++ b/spot/collect_test.go
@@ -1,0 +1,52 @@
+package spot
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"basis_go/types"
+)
+
+func TestCollectSpotPrices_WithFetchers(t *testing.T) {
+	fetchers := map[string]func() map[string]types.ExchangePrice{
+		"ex1": func() map[string]types.ExchangePrice {
+			return map[string]types.ExchangePrice{
+				"BTC/USDT": {Price: 1},
+			}
+		},
+		"ex2": func() map[string]types.ExchangePrice {
+			return map[string]types.ExchangePrice{
+				"BTC/USDT": {Price: 2},
+				"ETH/USDT": {Price: 3},
+			}
+		},
+		"empty": func() map[string]types.ExchangePrice { return nil },
+	}
+
+	r, w, _ := os.Pipe()
+	old := os.Stdout
+	os.Stdout = w
+	res := CollectSpotPrices(fetchers)
+	w.Close()
+	os.Stdout = old
+	var buf bytes.Buffer
+	io.Copy(&buf, r)
+	out := buf.String()
+
+	if !strings.Contains(out, "[empty] НЕ ОТДАЁТ ДАННЫХ") {
+		t.Fatalf("expected warning for empty fetcher, got: %s", out)
+	}
+
+	if len(res) != 2 {
+		t.Fatalf("expected 2 tokens, got %d", len(res))
+	}
+	if len(res["BTC/USDT"]) != 2 {
+		t.Fatalf("expected BTC/USDT on 2 exchanges, got %v", res["BTC/USDT"])
+	}
+	if p := res["ETH/USDT"]["ex2"].Price; p != 3 {
+		t.Fatalf("expected ETH price 3, got %v", p)
+	}
+}


### PR DESCRIPTION
## Summary
- allow optional custom sources in `CollectSpotPrices` and `CollectFuturesPrices`
- add tests for using stub fetchers

## Testing
- `go build ./...`
- `go test ./...`
