### PR TITLE
Add comparison funding/sorting test

### DIFF
--- a/comparison_price/spot_futures_compare_test.go
+++ b/comparison_price/spot_futures_compare_test.go
@@ -8,18 +8,43 @@ import (
 	"testing"
 	"time"
 
+	"basis_go/funding"
 	"basis_go/types"
 )
 
 func TestCompareSpotFutures(t *testing.T) {
+	now := time.Now()
+
 	spotPrices := types.TokenPrices{
 		"BTC/USDT": {
-			"ex1": {Price: 100},
+			"ex_spot": {Price: 100},
+		},
+		"ETH/USDT": {
+			"ex_spot": {Price: 50},
 		},
 	}
+
+	btcFundingTime := now.Add(2 * time.Hour).UnixMilli()
+	ethFundingTime := now.Add(1 * time.Hour).UnixMilli()
+
 	futuresPrices := types.TokenPrices{
 		"BTC/USDT": {
-			"ex2": {Price: 102, IsFutures: true, FundingRate: 0.001, FundingTime: time.Now().Add(1 * time.Hour).UnixMilli(), FundingIntervalH: 8},
+			"ex_fut": {
+				Price:            110,
+				IsFutures:        true,
+				FundingRate:      0.001,
+				FundingTime:      btcFundingTime,
+				FundingIntervalH: 8,
+			},
+		},
+		"ETH/USDT": {
+			"ex_fut": {
+				Price:            65,
+				IsFutures:        true,
+				FundingRate:      0.002,
+				FundingTime:      ethFundingTime,
+				FundingIntervalH: 8,
+			},
 		},
 	}
 
@@ -29,13 +54,27 @@ func TestCompareSpotFutures(t *testing.T) {
 	CompareSpotFutures(spotPrices, futuresPrices)
 	w.Close()
 	os.Stdout = old
+
 	var buf bytes.Buffer
 	io.Copy(&buf, r)
 	out := buf.String()
-	if !strings.Contains(out, "BTC/USDT") {
-		t.Fatalf("output missing token: %s", out)
+
+	expectedFundingETH := funding.FormatFunding(0.002, ethFundingTime, 65, 1.0, 8)
+	expectedFundingBTC := funding.FormatFunding(0.001, btcFundingTime, 110, 1.0, 8)
+
+	if !strings.Contains(out, expectedFundingETH) {
+		t.Fatalf("ETH funding formatting mismatch: %s", out)
 	}
-	if !strings.Contains(out, "0.100%") {
-		t.Fatalf("output missing funding info: %s", out)
+	if !strings.Contains(out, expectedFundingBTC) {
+		t.Fatalf("BTC funding formatting mismatch: %s", out)
+	}
+
+	ethIndex := strings.Index(out, "[ETH/USDT]")
+	btcIndex := strings.Index(out, "[BTC/USDT]")
+	if ethIndex == -1 || btcIndex == -1 {
+		t.Fatalf("missing token output: %s", out)
+	}
+	if ethIndex > btcIndex {
+		t.Fatalf("results not sorted by spread: %s", out)
 	}
 }


### PR DESCRIPTION
## Summary
- add a new `CompareSpotFutures` test with funding data
- ensure output is sorted by spread and funding info formatted

## Testing
- `go build ./...`
- `go test ./...`
