### PR TITLE
Add httptest coverage for markets

### DIFF
--- a/pump_monitor/markets/binance.go
+++ b/pump_monitor/markets/binance.go
@@ -8,6 +8,8 @@ import (
 	"time"
 )
 
+var binanceTickersURL = "https://api.binance.com/api/v3/ticker/24hr"
+
 type BinanceTicker struct {
 	Symbol string `json:"symbol"`
 	Price  string `json:"lastPrice"`
@@ -16,7 +18,7 @@ type BinanceTicker struct {
 
 func FetchBinanceTickers() (map[string]types.PriceInfo, error) {
 	client := &http.Client{Timeout: 10 * time.Second}
-	resp, err := client.Get("https://api.binance.com/api/v3/ticker/24hr")
+	resp, err := client.Get(binanceTickersURL)
 	if err != nil {
 		return nil, err
 	}

--- a/pump_monitor/markets/binance_test.go
+++ b/pump_monitor/markets/binance_test.go
@@ -1,0 +1,41 @@
+package markets
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestFetchBinanceTickers(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`[{"symbol":"BTCUSDT","lastPrice":"1.5","quoteVolume":"10"}]`))
+	}))
+	defer srv.Close()
+	old := binanceTickersURL
+	binanceTickersURL = srv.URL
+	defer func() { binanceTickersURL = old }()
+
+	prices, err := FetchBinanceTickers()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	p, ok := prices["BTCUSDT"]
+	if !ok || p.Price != 1.5 || p.Volume != 10 || p.QuoteVolume != 10 {
+		t.Fatalf("unexpected result: %+v", prices)
+	}
+}
+
+func TestFetchBinanceTickers_BadJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("bad"))
+	}))
+	defer srv.Close()
+	old := binanceTickersURL
+	binanceTickersURL = srv.URL
+	defer func() { binanceTickersURL = old }()
+
+	if _, err := FetchBinanceTickers(); err == nil {
+		t.Fatalf("expected error")
+	}
+}

--- a/pump_monitor/markets/bybit.go
+++ b/pump_monitor/markets/bybit.go
@@ -9,6 +9,11 @@ import (
 	"time"
 )
 
+var (
+	bybitTickersURL      = "https://api.bybit.com/v5/market/tickers?category=spot"
+	bybitRecentTradesURL = "https://api.bybit.com/v5/market/recent-trade?category=spot&symbol=%s"
+)
+
 type BybitSpotTicker struct {
 	Symbol      string `json:"symbol"`
 	LastPrice   string `json:"lastPrice"`
@@ -24,7 +29,7 @@ type BybitTrade struct {
 }
 
 func FetchBybitTickers() (map[string]types.PriceInfo, error) {
-	url := "https://api.bybit.com/v5/market/tickers?category=spot"
+	url := bybitTickersURL
 	client := &http.Client{Timeout: 10 * time.Second}
 	resp, err := client.Get(url)
 	if err != nil {
@@ -71,7 +76,7 @@ func FetchBybitTickers() (map[string]types.PriceInfo, error) {
 }
 
 func FetchRecentBybitTrades(symbol string) ([]BybitTrade, error) {
-	url := fmt.Sprintf("https://api.bybit.com/v5/market/recent-trade?category=spot&symbol=%s", symbol)
+	url := fmt.Sprintf(bybitRecentTradesURL, symbol)
 	client := &http.Client{Timeout: 10 * time.Second}
 	resp, err := client.Get(url)
 	if err != nil {

--- a/pump_monitor/markets/bybit_test.go
+++ b/pump_monitor/markets/bybit_test.go
@@ -1,0 +1,73 @@
+package markets
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestFetchBybitTickers(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"retCode":0,"result":{"category":"spot","list":[{"symbol":"BTCUSDT","lastPrice":"2","turnover24h":"20","volume24h":"1"}]}}`))
+	}))
+	defer srv.Close()
+	old := bybitTickersURL
+	bybitTickersURL = srv.URL
+	defer func() { bybitTickersURL = old }()
+
+	prices, err := FetchBybitTickers()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	p, ok := prices["BTCUSDT"]
+	if !ok || p.Price != 2 || p.Volume != 1 || p.QuoteVolume != 20 {
+		t.Fatalf("unexpected result: %+v", prices)
+	}
+}
+
+func TestFetchBybitTickers_BadJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("bad"))
+	}))
+	defer srv.Close()
+	old := bybitTickersURL
+	bybitTickersURL = srv.URL
+	defer func() { bybitTickersURL = old }()
+	if _, err := FetchBybitTickers(); err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
+func TestFetchRecentBybitTrades(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"retCode":0,"result":{"category":"spot","list":[{"price":"1","qty":"0.5","side":"Buy","time":1}]}}`))
+	}))
+	defer srv.Close()
+	old := bybitRecentTradesURL
+	bybitRecentTradesURL = srv.URL + "?symbol=%s"
+	defer func() { bybitRecentTradesURL = old }()
+
+	trades, err := FetchRecentBybitTrades("BTCUSDT")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(trades) != 1 || trades[0].Price != "1" {
+		t.Fatalf("unexpected trades: %+v", trades)
+	}
+}
+
+func TestFetchRecentBybitTrades_BadJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("bad"))
+	}))
+	defer srv.Close()
+	old := bybitRecentTradesURL
+	bybitRecentTradesURL = srv.URL + "?symbol=%s"
+	defer func() { bybitRecentTradesURL = old }()
+
+	if _, err := FetchRecentBybitTrades("BTCUSDT"); err == nil {
+		t.Fatalf("expected error")
+	}
+}

--- a/pump_monitor/markets/gate.go
+++ b/pump_monitor/markets/gate.go
@@ -10,6 +10,11 @@ import (
 	"time"
 )
 
+var (
+	gateTickersURL      = "https://api.gateio.ws/api/v4/spot/tickers"
+	gateRecentTradesURL = "https://api.gate.io/api/v4/spot/trades?currency_pair=%s"
+)
+
 type GateSpotTicker struct {
 	Symbol      string `json:"currency_pair"`
 	Last        string `json:"last"`
@@ -25,7 +30,7 @@ type GateTrade struct {
 }
 
 func FetchGateTickers() (map[string]types.PriceInfo, error) {
-	url := "https://api.gateio.ws/api/v4/spot/tickers"
+	url := gateTickersURL
 
 	client := &http.Client{
 		Timeout: 10 * time.Second,
@@ -87,7 +92,7 @@ func FetchGateTickers() (map[string]types.PriceInfo, error) {
 }
 
 func FetchRecentGateTrades(symbol string) ([]GateTrade, error) {
-	url := fmt.Sprintf("https://api.gate.io/api/v4/spot/trades?currency_pair=%s", symbol)
+	url := fmt.Sprintf(gateRecentTradesURL, symbol)
 	client := &http.Client{Timeout: 10 * time.Second}
 	resp, err := client.Get(url)
 	if err != nil {

--- a/pump_monitor/markets/gate_fetch_test.go
+++ b/pump_monitor/markets/gate_fetch_test.go
@@ -1,0 +1,74 @@
+package markets
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestFetchGateTickers(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`[{"currency_pair":"BTC_USDT","last":"3","base_volume":"4","quote_volume":"4"}]`))
+	}))
+	defer srv.Close()
+	old := gateTickersURL
+	gateTickersURL = srv.URL
+	defer func() { gateTickersURL = old }()
+
+	prices, err := FetchGateTickers()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	p, ok := prices["BTCUSDT"]
+	if !ok || p.Price != 3 || p.Volume != 4 || p.QuoteVolume != 4 {
+		t.Fatalf("unexpected prices: %+v", prices)
+	}
+}
+
+func TestFetchGateTickers_BadJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("bad"))
+	}))
+	defer srv.Close()
+	old := gateTickersURL
+	gateTickersURL = srv.URL
+	defer func() { gateTickersURL = old }()
+
+	if _, err := FetchGateTickers(); err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
+func TestFetchRecentGateTrades(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`[{"price":"1","amount":"2","create_time_ms":1,"side":"buy"}]`))
+	}))
+	defer srv.Close()
+	old := gateRecentTradesURL
+	gateRecentTradesURL = srv.URL + "?currency_pair=%s"
+	defer func() { gateRecentTradesURL = old }()
+
+	trades, err := FetchRecentGateTrades("BTC_USDT")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(trades) != 1 || trades[0].Price != "1" {
+		t.Fatalf("unexpected trades: %+v", trades)
+	}
+}
+
+func TestFetchRecentGateTrades_BadJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("bad"))
+	}))
+	defer srv.Close()
+	old := gateRecentTradesURL
+	gateRecentTradesURL = srv.URL + "?currency_pair=%s"
+	defer func() { gateRecentTradesURL = old }()
+
+	if _, err := FetchRecentGateTrades("BTC_USDT"); err == nil {
+		t.Fatalf("expected error")
+	}
+}

--- a/pump_monitor/markets/mexc.go
+++ b/pump_monitor/markets/mexc.go
@@ -8,6 +8,11 @@ import (
 	"time"
 )
 
+var (
+	mexcTickersURL      = "https://api.mexc.com/api/v3/ticker/24hr"
+	mexcRecentTradesURL = "https://api.mexc.com/api/v3/trades?symbol=%s"
+)
+
 type MEXCSpotTicker struct {
 	Symbol    string `json:"symbol"`
 	LastPrice string `json:"lastPrice"`
@@ -22,7 +27,7 @@ type Trade struct {
 }
 
 func FetchMEXCTickers() (map[string]types.PriceInfo, error) {
-	url := "https://api.mexc.com/api/v3/ticker/24hr"
+	url := mexcTickersURL
 	client := &http.Client{Timeout: 10 * time.Second}
 	resp, err := client.Get(url)
 	if err != nil {
@@ -53,7 +58,7 @@ func FetchMEXCTickers() (map[string]types.PriceInfo, error) {
 }
 
 func FetchRecentTrades(symbol string) ([]Trade, error) {
-	url := fmt.Sprintf("https://api.mexc.com/api/v3/trades?symbol=%s", symbol)
+	url := fmt.Sprintf(mexcRecentTradesURL, symbol)
 	client := &http.Client{Timeout: 10 * time.Second}
 	resp, err := client.Get(url)
 	if err != nil {

--- a/pump_monitor/markets/mexc_test.go
+++ b/pump_monitor/markets/mexc_test.go
@@ -1,0 +1,74 @@
+package markets
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestFetchMEXCTickers(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`[{"symbol":"BTCUSDT","lastPrice":"5","volume":"6"}]`))
+	}))
+	defer srv.Close()
+	old := mexcTickersURL
+	mexcTickersURL = srv.URL
+	defer func() { mexcTickersURL = old }()
+
+	prices, err := FetchMEXCTickers()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	p, ok := prices["BTCUSDT"]
+	if !ok || p.Price != 5 || p.Volume != 6 {
+		t.Fatalf("unexpected prices: %+v", prices)
+	}
+}
+
+func TestFetchMEXCTickers_BadJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("bad"))
+	}))
+	defer srv.Close()
+	old := mexcTickersURL
+	mexcTickersURL = srv.URL
+	defer func() { mexcTickersURL = old }()
+
+	if _, err := FetchMEXCTickers(); err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
+func TestFetchRecentTrades(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`[{"price":"1","qty":"2","isBuyerMaker":false,"time":1}]`))
+	}))
+	defer srv.Close()
+	old := mexcRecentTradesURL
+	mexcRecentTradesURL = srv.URL + "?symbol=%s"
+	defer func() { mexcRecentTradesURL = old }()
+
+	trades, err := FetchRecentTrades("BTCUSDT")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(trades) != 1 || trades[0].Price != "1" {
+		t.Fatalf("unexpected trades: %+v", trades)
+	}
+}
+
+func TestFetchRecentTrades_BadJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("bad"))
+	}))
+	defer srv.Close()
+	old := mexcRecentTradesURL
+	mexcRecentTradesURL = srv.URL + "?symbol=%s"
+	defer func() { mexcRecentTradesURL = old }()
+
+	if _, err := FetchRecentTrades("BTCUSDT"); err == nil {
+		t.Fatalf("expected error")
+	}
+}


### PR DESCRIPTION
## Summary
- allow overriding exchange URLs for tests
- add tests for Binance, Bybit, Gate and MEXC market fetchers

## Testing
- `go build ./...`
- `go test ./...`
