### PR TITLE
Add futures coverage in CompareAll tests

### DIFF
--- a/core/analyzer_test.go
+++ b/core/analyzer_test.go
@@ -3,11 +3,13 @@ package core
 import (
 	"bytes"
 	"io"
+	"log"
 	"os"
 	"strings"
 	"testing"
 
 	"basis_go/types"
+	"time"
 )
 
 func TestCompareAll(t *testing.T) {
@@ -32,5 +34,53 @@ func TestCompareAll(t *testing.T) {
 	}
 	if !strings.Contains(out, "Спред") {
 		t.Fatalf("output missing spread info: %s", out)
+	}
+}
+
+func TestCompareAll_SortingFunding(t *testing.T) {
+	now := time.Now()
+	prices := types.TokenPrices{
+		"ETH/USDT": {
+			"SpotEx": {Price: 1000},
+			"FutEx": {
+				Price:            1100,
+				IsFutures:        true,
+				FundingRate:      0.001,
+				FundingIntervalH: 8,
+				NextFundingTime:  now.Add(time.Hour),
+			},
+		},
+		"BTC/USDT": {
+			"FutEx": {
+				Price:            21000,
+				IsFutures:        true,
+				FundingRate:      -0.002,
+				FundingIntervalH: 8,
+				NextFundingTime:  now.Add(2 * time.Hour),
+			},
+			"SpotEx": {Price: 20000},
+		},
+	}
+
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	defer log.SetOutput(os.Stderr)
+
+	r, w, _ := os.Pipe()
+	old := os.Stdout
+	os.Stdout = w
+	CompareAll(prices)
+	w.Close()
+	os.Stdout = old
+	io.Copy(&buf, r)
+	out := buf.String()
+
+	btc := strings.Index(out, "[BTC/USDT]")
+	eth := strings.Index(out, "[ETH/USDT]")
+	if btc == -1 || eth == -1 || btc > eth {
+		t.Fatalf("tokens not sorted: %s", out)
+	}
+	if !strings.Contains(out, "Фьючерс") || !strings.Contains(out, "Фандинг") {
+		t.Fatalf("futures funding info missing: %s", out)
 	}
 }


### PR DESCRIPTION
## Summary
- expand `analyzer_test.go` with a new test
- verify sorting and funding info output from `CompareAll`

## Testing
- `go build ./...`
- `go test ./...`
