### PR TITLE
Refactor main loop and add tests

### DIFF
--- a/main.go
+++ b/main.go
@@ -12,6 +12,66 @@ import (
 	"github.com/joho/godotenv"
 )
 
+// function variables allow tests to stub expensive operations
+var (
+	collectSpotPrices    = spot.CollectSpotPrices
+	compareSpotPrices    = spot.CompareSpotPrices
+	collectFuturesPrices = futures.CollectFuturesPrices
+	compareFuturesPrices = futures.ComparePrices
+	compareSpotFutures   = comparison_price.CompareSpotFutures
+	monitorPumps         = pump_monitor.MonitorPumps
+)
+
+// runOnce controls whether runMode executes only a single iteration. It is
+// intended for tests.
+var runOnce bool
+
+// runMode executes the logic for the provided mode. If once is true, only a
+// single iteration is executed.
+func runMode(mode string, once bool) {
+	for {
+		start := time.Now()
+
+		switch mode {
+		case "spot":
+			sp := collectSpotPrices()
+			compareSpotPrices(sp)
+
+		case "futures":
+			fp := collectFuturesPrices()
+			compareFuturesPrices(fp)
+
+		case "spotfutures":
+			sp := collectSpotPrices()
+			fp := collectFuturesPrices()
+			compareSpotFutures(sp, fp)
+
+		case "pump":
+			monitorPumps()
+			return
+
+		case "all":
+			sp := collectSpotPrices()
+			compareSpotPrices(sp)
+
+			fp := collectFuturesPrices()
+			compareFuturesPrices(fp)
+
+			compareSpotFutures(sp, fp)
+
+		default:
+			fmt.Println("❌ Неизвестный режим. Используйте: -mode=spot, -mode=futures, -mode=spotfutures, -mode=pump или -mode=all")
+			return
+		}
+
+		fmt.Printf("⏱ Цикл занял: %.2fs\n", time.Since(start).Seconds())
+		if once {
+			return
+		}
+		time.Sleep(15 * time.Second)
+	}
+}
+
 func main() {
 	err := godotenv.Load("/Users/vladyslav/Documents/Проекты /basis_go/.env")
 	if err != nil {
@@ -22,42 +82,5 @@ func main() {
 	mode := flag.String("mode", "all", "Режим запуска: spot, futures, spotfutures, pump, all")
 	flag.Parse()
 
-	for {
-		start := time.Now()
-
-		switch *mode {
-		case "spot":
-			spotPrices := spot.CollectSpotPrices()
-			spot.CompareSpotPrices(spotPrices)
-
-		case "futures":
-			futuresPrices := futures.CollectFuturesPrices()
-			futures.ComparePrices(futuresPrices)
-
-		case "spotfutures":
-			spotPrices := spot.CollectSpotPrices()
-			futuresPrices := futures.CollectFuturesPrices()
-			comparison_price.CompareSpotFutures(spotPrices, futuresPrices)
-
-		case "pump":
-			pump_monitor.MonitorPumps()
-			return
-
-		case "all":
-			spotPrices := spot.CollectSpotPrices()
-			spot.CompareSpotPrices(spotPrices)
-
-			futuresPrices := futures.CollectFuturesPrices()
-			futures.ComparePrices(futuresPrices)
-
-			comparison_price.CompareSpotFutures(spotPrices, futuresPrices)
-
-		default:
-			fmt.Println("❌ Неизвестный режим. Используйте: -mode=spot, -mode=futures, -mode=spotfutures, -mode=pump или -mode=all")
-			return
-		}
-
-		fmt.Printf("⏱ Цикл занял: %.2fs\n", time.Since(start).Seconds())
-		time.Sleep(15 * time.Second)
-	}
+	runMode(*mode, runOnce)
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"flag"
+	"os"
+	"testing"
+
+	"basis_go/types"
+)
+
+func resetFlags() {
+	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+}
+
+func TestRunModeSpot(t *testing.T) {
+	runOnce = true
+	resetFlags()
+	os.Args = []string{"cmd", "-mode=spot"}
+	called := []string{}
+
+	collectSpotPrices = func(fetchers ...map[string]func() map[string]types.ExchangePrice) types.TokenPrices {
+		called = append(called, "collectSpot")
+		return types.TokenPrices{}
+	}
+	compareSpotPrices = func(types.TokenPrices) { called = append(called, "compareSpot") }
+
+	main()
+
+	if len(called) != 2 || called[0] != "collectSpot" || called[1] != "compareSpot" {
+		t.Fatalf("spot mode not executed correctly: %v", called)
+	}
+}
+
+func TestRunModeFutures(t *testing.T) {
+	runOnce = true
+	resetFlags()
+	os.Args = []string{"cmd", "-mode=futures"}
+	called := []string{}
+
+	collectFuturesPrices = func(fetchers ...map[string]func() map[string]types.ExchangePrice) types.TokenPrices {
+		called = append(called, "collectFutures")
+		return types.TokenPrices{}
+	}
+	compareFuturesPrices = func(types.TokenPrices) { called = append(called, "compareFutures") }
+
+	main()
+
+	if len(called) != 2 || called[0] != "collectFutures" || called[1] != "compareFutures" {
+		t.Fatalf("futures mode not executed correctly: %v", called)
+	}
+}
+
+func TestRunModeSpotFutures(t *testing.T) {
+	runOnce = true
+	resetFlags()
+	os.Args = []string{"cmd", "-mode=spotfutures"}
+	called := []string{}
+
+	collectSpotPrices = func(fetchers ...map[string]func() map[string]types.ExchangePrice) types.TokenPrices {
+		called = append(called, "collectSpot")
+		return types.TokenPrices{}
+	}
+	collectFuturesPrices = func(fetchers ...map[string]func() map[string]types.ExchangePrice) types.TokenPrices {
+		called = append(called, "collectFutures")
+		return types.TokenPrices{}
+	}
+	compareSpotFutures = func(types.TokenPrices, types.TokenPrices) { called = append(called, "compareSpotFutures") }
+
+	main()
+
+	expected := []string{"collectSpot", "collectFutures", "compareSpotFutures"}
+	for i, v := range expected {
+		if i >= len(called) || called[i] != v {
+			t.Fatalf("spotfutures mode not executed correctly: %v", called)
+		}
+	}
+}
+
+func TestRunModePump(t *testing.T) {
+	runOnce = true
+	resetFlags()
+	os.Args = []string{"cmd", "-mode=pump"}
+	called := false
+	monitorPumps = func() { called = true }
+
+	main()
+
+	if !called {
+		t.Fatalf("pump mode not executed")
+	}
+}
+
+func TestRunModeDefault(t *testing.T) {
+	runOnce = true
+	resetFlags()
+	os.Args = []string{"cmd", "-mode=unknown"}
+	called := false
+	collectSpotPrices = func(fetchers ...map[string]func() map[string]types.ExchangePrice) types.TokenPrices {
+		called = true
+		return nil
+	}
+
+	main()
+
+	if called {
+		t.Fatalf("default branch should not call any collect functions")
+	}
+}


### PR DESCRIPTION
## Summary
- factor out main loop logic into `runMode`
- expose function variables for easy stubbing in tests
- add `runOnce` flag for single-iteration runs
- test different `-mode` values using stubs

## Testing
- `go build ./...`
- `go test ./...`
