### PR TITLE
Add exchange request tests

### DIFF
--- a/exchangerequests/binance/binance_test.go
+++ b/exchangerequests/binance/binance_test.go
@@ -1,0 +1,73 @@
+package exchangerequests
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+)
+
+type rewriteTransport struct {
+	base *url.URL
+	rt   http.RoundTripper
+}
+
+func (t rewriteTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.URL.Scheme = t.base.Scheme
+	req.URL.Host = t.base.Host
+	return t.rt.RoundTrip(req)
+}
+
+func withTestServer(t *testing.T, handler http.Handler) func() {
+	srv := httptest.NewServer(handler)
+	u, _ := url.Parse(srv.URL)
+	old := http.DefaultTransport
+	http.DefaultTransport = rewriteTransport{base: u, rt: old}
+	return func() {
+		http.DefaultTransport = old
+		srv.Close()
+	}
+}
+
+func TestBinanceSpotGetPrices(t *testing.T) {
+	h := http.NewServeMux()
+	h.HandleFunc("/api/v3/ticker/bookTicker", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`[{"symbol":"BTCUSDT","bidPrice":"50000","askPrice":"50100"}]`))
+	})
+	cleanup := withTestServer(t, h)
+	defer cleanup()
+
+	prices := GetSpotPrices()
+	p, ok := prices["BTC/USDT"]
+	if !ok || p.IsFutures {
+		t.Fatalf("bad price: %+v", p)
+	}
+	if p.Price != 50100 || p.Volume != 50000 {
+		t.Fatalf("unexpected values: %+v", p)
+	}
+}
+
+func TestBinanceFuturesGetPrices(t *testing.T) {
+	h := http.NewServeMux()
+	h.HandleFunc("/fapi/v1/ticker/bookTicker", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`[{"symbol":"BTCUSDT","askPrice":"50100","bidPrice":"50000"}]`))
+	})
+	h.HandleFunc("/fapi/v1/premiumIndex", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`[{"symbol":"BTCUSDT","lastFundingRate":"0.01","nextFundingTime":1700000000000}]`))
+	})
+	cleanup := withTestServer(t, h)
+	defer cleanup()
+
+	prices := GetFuturesPrices()
+	p, ok := prices["BTC/USDT"]
+	if !ok || !p.IsFutures {
+		t.Fatalf("bad price: %+v", p)
+	}
+	if p.Price != 50100 || p.Volume != 50000 {
+		t.Fatalf("unexpected values: %+v", p)
+	}
+	if p.FundingRate != 0.01 || !p.NextFundingTime.Equal(time.UnixMilli(1700000000000)) {
+		t.Fatalf("unexpected funding: %+v", p)
+	}
+}

--- a/exchangerequests/bybit/bybit_test.go
+++ b/exchangerequests/bybit/bybit_test.go
@@ -1,0 +1,85 @@
+package exchangerequests
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+)
+
+type rewriteTransport struct {
+	base *url.URL
+	rt   http.RoundTripper
+}
+
+func (t rewriteTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.URL.Scheme = t.base.Scheme
+	req.URL.Host = t.base.Host
+	return t.rt.RoundTrip(req)
+}
+
+func withTestServer(t *testing.T, handler http.Handler) func() {
+	srv := httptest.NewServer(handler)
+	u, _ := url.Parse(srv.URL)
+	old := http.DefaultTransport
+	http.DefaultTransport = rewriteTransport{base: u, rt: old}
+	return func() {
+		http.DefaultTransport = old
+		srv.Close()
+	}
+}
+
+func TestBybitSpotGetPrices(t *testing.T) {
+	h := http.NewServeMux()
+	h.HandleFunc("/v5/market/tickers", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("category") != "spot" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Write([]byte(`{"retCode":0,"result":{"list":[{"symbol":"BTCUSDT","bid1Price":"50000","ask1Price":"50100"}]}}`))
+	})
+	cleanup := withTestServer(t, h)
+	defer cleanup()
+
+	prices := GetSpotPrices()
+	p, ok := prices["BTC/USDT"]
+	if !ok || p.IsFutures {
+		t.Fatalf("bad price: %+v", p)
+	}
+	if p.Price != 50100 || p.Volume != 50000 {
+		t.Fatalf("unexpected values: %+v", p)
+	}
+}
+
+func TestBybitFuturesGetPrices(t *testing.T) {
+	h := http.NewServeMux()
+	h.HandleFunc("/v5/market/tickers", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("category") != "linear" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Write([]byte(`{"retCode":0,"result":{"list":[{"symbol":"BTCUSDT","ask1Price":"50100","bid1Price":"50000"}]}}`))
+	})
+	h.HandleFunc("/v5/market/funding/history", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("category") != "linear" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Write([]byte(`{"retCode":0,"result":{"list":[{"symbol":"BTCUSDT","fundingRate":"0.02","fundingRateTimestamp":1700000000000}]}}`))
+	})
+	cleanup := withTestServer(t, h)
+	defer cleanup()
+
+	prices := (&BybitFutures{}).GetPrices()
+	p, ok := prices["BTC/USDT"]
+	if !ok || !p.IsFutures {
+		t.Fatalf("bad price: %+v", p)
+	}
+	if p.Price != 50100 || p.Volume != 50000 {
+		t.Fatalf("unexpected values: %+v", p)
+	}
+	if p.FundingRate != 0.02 || !p.NextFundingTime.Equal(time.UnixMilli(1700000000000)) {
+		t.Fatalf("unexpected funding: %+v", p)
+	}
+}

--- a/exchangerequests/gate/gate_test.go
+++ b/exchangerequests/gate/gate_test.go
@@ -1,0 +1,73 @@
+package exchangerequests
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+)
+
+type rewriteTransport struct {
+	base *url.URL
+	rt   http.RoundTripper
+}
+
+func (t rewriteTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.URL.Scheme = t.base.Scheme
+	req.URL.Host = t.base.Host
+	return t.rt.RoundTrip(req)
+}
+
+func withTestServer(t *testing.T, handler http.Handler) func() {
+	srv := httptest.NewServer(handler)
+	u, _ := url.Parse(srv.URL)
+	old := http.DefaultTransport
+	http.DefaultTransport = rewriteTransport{base: u, rt: old}
+	return func() {
+		http.DefaultTransport = old
+		srv.Close()
+	}
+}
+
+func TestGateSpotGetPrices(t *testing.T) {
+	h := http.NewServeMux()
+	h.HandleFunc("/api/v4/spot/tickers", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`[{"currency_pair":"BTC_USDT","last":"50100","base_volume":"50000"}]`))
+	})
+	cleanup := withTestServer(t, h)
+	defer cleanup()
+
+	prices := GetSpotPrices()
+	p, ok := prices["BTC/USDT"]
+	if !ok || p.IsFutures {
+		t.Fatalf("bad price: %+v", p)
+	}
+	if p.Price != 50100 || p.Volume != 50000 {
+		t.Fatalf("unexpected values: %+v", p)
+	}
+}
+
+func TestGateFuturesGetPrices(t *testing.T) {
+	h := http.NewServeMux()
+	h.HandleFunc("/api/v4/futures/usdt/tickers", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`[{"contract":"BTC_USDT","last":"50100","volume_24h_quote":"50000"}]`))
+	})
+	h.HandleFunc("/api/v4/futures/usdt/funding_rates", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"data":[{"contract":"BTC_USDT","funding_rate":"0.03","funding_time":"1700000000000"}]}`))
+	})
+	cleanup := withTestServer(t, h)
+	defer cleanup()
+
+	prices := GetGateFuturesPrices()
+	p, ok := prices["BTC/USDT"]
+	if !ok || !p.IsFutures {
+		t.Fatalf("bad price: %+v", p)
+	}
+	if p.Price != 50100 || p.Volume != 50000 {
+		t.Fatalf("unexpected values: %+v", p)
+	}
+	if p.FundingRate != 0.03 || !p.NextFundingTime.Equal(time.UnixMilli(1700000000000)) {
+		t.Fatalf("unexpected funding: %+v", p)
+	}
+}

--- a/exchangerequests/mexc/mexc_test.go
+++ b/exchangerequests/mexc/mexc_test.go
@@ -1,0 +1,73 @@
+package exchangerequests
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+)
+
+type rewriteTransport struct {
+	base *url.URL
+	rt   http.RoundTripper
+}
+
+func (t rewriteTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.URL.Scheme = t.base.Scheme
+	req.URL.Host = t.base.Host
+	return t.rt.RoundTrip(req)
+}
+
+func withTestServer(t *testing.T, handler http.Handler) func() {
+	srv := httptest.NewServer(handler)
+	u, _ := url.Parse(srv.URL)
+	old := http.DefaultTransport
+	http.DefaultTransport = rewriteTransport{base: u, rt: old}
+	return func() {
+		http.DefaultTransport = old
+		srv.Close()
+	}
+}
+
+func TestMEXCSpotGetPrices(t *testing.T) {
+	h := http.NewServeMux()
+	h.HandleFunc("/api/v3/ticker/bookTicker", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`[{"symbol":"BTCUSDT","bidPrice":"50000","askPrice":"50100"}]`))
+	})
+	cleanup := withTestServer(t, h)
+	defer cleanup()
+
+	prices := GetSpotPrices()
+	p, ok := prices["BTC/USDT"]
+	if !ok || p.IsFutures {
+		t.Fatalf("bad price: %+v", p)
+	}
+	if p.Price != 50100 || p.Volume != 50000 {
+		t.Fatalf("unexpected values: %+v", p)
+	}
+}
+
+func TestMEXCFuturesGetPrices(t *testing.T) {
+	h := http.NewServeMux()
+	h.HandleFunc("/api/v1/contract/ticker", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"data":[{"symbol":"BTC_USDT","ask1":50100,"bid1":50000}]}`))
+	})
+	h.HandleFunc("/api/v1/contract/funding_rate", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"data":[{"symbol":"BTC_USDT","fundingRate":0.04,"nextFundingTime":1700000000000}]}`))
+	})
+	cleanup := withTestServer(t, h)
+	defer cleanup()
+
+	prices := (&MEXCFutures{}).GetPrices()
+	p, ok := prices["BTC/USDT"]
+	if !ok || !p.IsFutures {
+		t.Fatalf("bad price: %+v", p)
+	}
+	if p.Price != 50100 || p.Volume != 50000 {
+		t.Fatalf("unexpected values: %+v", p)
+	}
+	if p.FundingRate != 0.04 || !p.NextFundingTime.Equal(time.UnixMilli(1700000000000)) {
+		t.Fatalf("unexpected funding: %+v", p)
+	}
+}


### PR DESCRIPTION
## Summary
- create tests for each exchange in `exchangerequests`
- serve mock API responses via `httptest.Server`
- rewrite `http.DefaultTransport` so `GetSpotPrices` and `GetFuturesPrices` use the mocks
- assert parsed `types.ExchangePrice` values

## Testing
- `go build ./...`
- `go test ./...`
